### PR TITLE
Equivalence with the arkworks reference implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +630,7 @@ dependencies = [
  "digest 0.10.3",
  "elliptic-curve 0.12.2",
  "hash2field",
+ "hex",
  "hex-literal",
  "k256",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ num-bigint = "0.4.3"
 num-integer = "0.1.45"
 k256 = {version = "0.11.3", features = ["arithmetic", "hash2curve", "expose-field", "sha2"]}
 elliptic-curve = { version = "0.12.2", features = ["arithmetic"]}
+hex = "0.4.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@
 // #![feature(generic_const_expr)]
 // #![allow(incomplete_features)]
 
+use elliptic_curve::sec1::ToEncodedPoint;
 use elliptic_curve::group::GroupEncoding;
+use elliptic_curve::group::prime::PrimeCurveAffine;
 use elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest};
 use hex_literal::hex;
 use k256::{
@@ -20,6 +22,12 @@ const L: usize = 48;
 const COUNT: usize = 2;
 const OUT: usize = L * COUNT;
 const DST: &[u8] = b"QUUX-V01-CS02-with-secp256k1_XMD:SHA-256_SSWU_RO_"; // Hash to curve algorithm
+
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    IsPointAtInfinityError,
+}
+
 
 fn print_type_of<T>(_: &T) {
     println!("{}", std::any::type_name::<T>());
@@ -85,6 +93,7 @@ fn test_gen_signals(
 
     // The Fiat-Shamir type step.
     let c = sha512hash6signals(&g, &pk, &hash_m_pk, &nullifier, &g_r, &hash_m_pk_pow_r);
+    println!("c: {:?}", hex::encode(c.to_bytes()));
 
     // This value is part of the discrete log equivalence (DLEQ) proof.
     let r_sk_c = r + sk * c;
@@ -101,15 +110,28 @@ fn sha512hash6signals(
     g_r: &ProjectivePoint,
     hash_m_pk_pow_r: &ProjectivePoint,
 ) -> Scalar {
-    let mut hasher = Sha512::new();
-    hasher.update(g.to_bytes());
-    hasher.update(pk.to_bytes());
-    hasher.update(hash_m_pk.to_bytes());
-    hasher.update(nullifier.to_bytes());
-    hasher.update(g_r.to_bytes());
-    hasher.update(hash_m_pk_pow_r.to_bytes());
-    let c_raw = hasher.finalize(); //512 bit hash
-    let c_bytes = FieldBytes::from_iter(c_raw.iter().copied());
+    let g_bytes = pt_to_64_bytes(*g).unwrap();
+    let pk_bytes = pt_to_64_bytes(*pk).unwrap();
+    let h_bytes = pt_to_64_bytes(*hash_m_pk).unwrap();
+    let nul_bytes = pt_to_64_bytes(*nullifier).unwrap();
+    let g_r_bytes = pt_to_64_bytes(*g_r).unwrap();
+    let z_bytes = pt_to_64_bytes(*hash_m_pk_pow_r).unwrap();
+
+    let c_preimage_vec = [
+        g_bytes,
+        pk_bytes,
+        h_bytes,
+        nul_bytes,
+        g_r_bytes,
+        z_bytes,
+    ].concat();
+
+    let mut sha512_hasher = Sha512::new();
+    sha512_hasher.update(c_preimage_vec.as_slice());
+    let sha512_hasher_result = sha512_hasher.finalize(); //512 bit hash
+    println!("sha512_hasher_result {:?}", &sha512_hasher_result);
+
+    let c_bytes = FieldBytes::from_iter(sha512_hasher_result.iter().copied());
     let c_scalar = Scalar::from_repr(c_bytes).unwrap();
     c_scalar
 }
@@ -122,10 +144,10 @@ fn hash_to_secp(s: &[u8]) -> ProjectivePoint {
     pt
 }
 
-// Hashes two values to the curve [note that value concatenation here may not exactly translate to javascript etc]
+// Hashes two values to the curve
 fn hash_m_pk_to_secp(m: &[u8], pk: &ProjectivePoint) -> ProjectivePoint {
     let pt: ProjectivePoint = Secp256k1::hash_from_bytes::<ExpandMsgXmd<Sha256>>(
-        &[m, &pk.to_bytes()],
+        &[[m, &pt_to_64_bytes(*pk).unwrap()].concat().as_slice()],
         b"CURVE_XMD:SHA-256_SSWU_RO_",
     )
     .unwrap();
@@ -186,17 +208,74 @@ fn verify_signals(
 
 // NOTE: MAKE SURE TO HAVE RUST-ANALYZER ENABLED IN VSCODE EXTENSIONS TO FILL IN INFERRED TYPES
 fn main() -> Result<(), ()> {
+    let g = ProjectivePoint::GENERATOR;
+
     let m = b"An example app message string";
 
     // Fixed key nullifier, secret key, and random value for testing
     // Normally a secure enclave would generate these values, and output to a wallet implementation
     let (pk, g_r, hash_m_pk_pow_r, nullifier, c, r_sk_c) = test_gen_signals(m);
 
+    // The signer's secret key. It is only accessed within the secure enclave.
+    let sk = gen_test_scalar_x();
+    
+    // The user's public key: g^sk.
+    let pk = &g * &sk;
+
     // Verify the signals, normally this would happen in ZK with only the nullifier public, which would have a zk verifier instead
     // The wallet should probably run this prior to snarkify-ing as a sanity check
     // m and nullifier should be public, so we can verify that they are correct
-    let verified = verify_signals(m, &pk, &g_r, &hash_m_pk_pow_r, &nullifier, &c, &r_sk_c);
+    //let verified = verify_signals(m, &pk, &g_r, &hash_m_pk_pow_r, &nullifier, &c, &r_sk_c);
+    //println!("Verified: {}", verified);
+ 
+    //// Print g
+    //let g_bytes = g.to_bytes();
+    //println!("g.to_bytes(): {:?}", g_bytes);
 
-    println!("Verified: {}", verified);
+    //// Print uncompressed g.x and g.y
+    //let encoded_g = g.to_encoded_point(false);
+    //let encoded_g_x = encoded_g.x().unwrap();
+    //let encoded_g_y = encoded_g.y().unwrap();
+    //println!("encoded_g_x: {:?}", encoded_g_x);
+    //println!("encoded_g_y: {:?}", encoded_g_y);
+
+    // Format g as 64 bytes
+    let g_as_64_bytes = pt_to_64_bytes(g).unwrap();
+    assert_eq!(hex::encode(g_as_64_bytes), "9817f8165b81f259d928ce2ddbfc9b02070b87ce9562a055acbbdcf97e66be79b8d410fb8fd0479c195485a648b417fda808110efcfba45d65c4a32677da3a48");
+
+    // Attempting to convert the point at infinity to 64 bytes will fail
+    let pai = ProjectivePoint::IDENTITY;
+    let pai_as_64_bytes = pt_to_64_bytes(pai);
+    assert_eq!(pai_as_64_bytes.unwrap_err(), Error::IsPointAtInfinityError);
+
     Ok(())
+}
+
+/// Format a ProjectivePoint to 64 bytes - the concatenation of the x and y values.  We use 64
+/// bytes instead of SEC1 encoding as our arkworks secp256k1 implementation doesn't support SEC1
+/// encoding yet.
+fn pt_to_64_bytes(
+    pt: ProjectivePoint
+) -> Result<Vec::<u8>, Error> {
+    if pt.to_affine().is_identity().unwrap_u8() == 1 {
+        return Err(Error::IsPointAtInfinityError);
+    }
+
+    let encoded_pt = pt.to_encoded_point(false);
+    let encoded_pt_x = encoded_pt.x().unwrap();
+    let encoded_pt_y = encoded_pt.y().unwrap();
+
+    let mut x_bytes_vec = vec![0u8; 32];
+    let mut y_bytes_vec = vec![0u8; 32];
+
+    for (i, _) in encoded_pt_x.clone().iter().enumerate() {
+        let _ = std::mem::replace(&mut x_bytes_vec[i], encoded_pt_x[encoded_pt_x.len() - 1 - i]);
+    }
+
+    for (i, _) in encoded_pt_y.clone().iter().enumerate() {
+        let _ = std::mem::replace(&mut y_bytes_vec[i], encoded_pt_y[encoded_pt_y.len() - 1 - i]);
+    }
+
+    x_bytes_vec.append(&mut y_bytes_vec);
+    Ok(x_bytes_vec)
 }


### PR DESCRIPTION
I've implemented the signature scheme in arkworks: https://github.com/geometryresearch/deterministic_nullifier_sigs

This PR makes some changes to make the k256-based implementation equivalent to the above arkworks implementation.

1. I implemented a `pt_to_64_bytes()` function which encodes a secp256k1 point as 64 bytes. This is less than ideal (as SEC1 encoding, which k256 provides, outputs fewer bytes), but until SEC1 encoding is implemented for secp256k1 in arkworks, it will do.
2. The input to the sha512 is now a concatenated byte array of the relevant values. Previously, `hasher.update()` was invoked once per value.
3. The input to `Secp256k1::hash_from_bytes()` is now a concatenated byte array of the message and the public key (encoded as 64 bytes - see above). Previously, it was an array of two byte arrays.
4. The main program outputs each value in the signature. The arkworks reference implementation contains tests which checks against said values (given the same hardcoded secret key and `r`).

```
Verified: true
nullifier.x: "09087d02121b2cebf2ed5b25674753d7e5a52b60b86e15488ebdbc28646b6ade"
nullifier.y: "c964a5d8a292a8878d1c52cb91c5173c2d15eff720d2b4d135b69bd165457597"
c: "d52d5492448ee7aafd7d7bfff39d9819954c54f8e2517e29a07d299d268e3a11"
r_sk_c: "2c079c66390abbf6cd11190905084391fead39fde8f491bd4a53fdf767a5cc5f"
g_r.x: "9d8ca4350e7e2ad27abc6d2a281365818076662962a28429590e2dc736fe9804"
g_r.y: "ff08c30b8afd4e854623c835d9c3aac6bcebe45112472d9b9054816a7670c5a1"
hash_m_pk_pow_r.x: "cb5948e1ba7f305da52f846c345d880a1cb7ca2c9924d2ce92134a5a20daaea7"
hash_m_pk_pow_r.y: "153a05bf994bfbc6ef39e267f69edc00aeaaf505ec43ff278a2f1ca11e0edda9"
```